### PR TITLE
[Feat #52] 업로드 문제집 수 추가

### DIFF
--- a/src/components/mypage/MyPageHome.jsx
+++ b/src/components/mypage/MyPageHome.jsx
@@ -64,11 +64,18 @@ const MyPageHome = () => {
             <div className="flex flex-col md:flex-row gap-8">
                 {/* 블럭 ② : 레벨 정보 */}
                 <section className="flex-1 bg-white rounded-3xl p-8 flex items-center justify-between shadow-lg">
+                    {/* 랭킹 */}
+                    <div className="px-4 text-center">
+                        <p className="text-4xl font-bold text-[#5F360A]">{stats.ranking}</p>
+                        <p className="mt-2 text-sm text-[#5F360A]/70">나의 랭킹</p>
+                    </div>
+                    <div className="hidden md:block w-px h-12 bg-[#e0d5c5]" />
                     {/* 왼쪽: 아이콘 + 레벨 */}
                     <div className="flex items-center gap-6">
                         <LevelIcon level={user.level} size={80} />
                         <h3 className="text-xl font-bold text-[#5F360A]">
-                            Lv.&nbsp;{user.level}&nbsp;{className}
+                            {/* Lv.&nbsp;{user.level}&nbsp; */}
+                            {className}
                         </h3>
                     </div>
 
@@ -83,27 +90,28 @@ const MyPageHome = () => {
 
                 {/* 블럭 ③ : 통계(랭킹·문제집) */}
                 <section className="flex-1 bg-white rounded-3xl p-8 flex justify-around items-center shadow-lg text-center">
-                    {/* ⓐ 랭킹 */}
-                    <div className="px-4">
-                        <p className="text-4xl font-bold text-[#5F360A]">{stats.ranking}</p>
-                        <p className="mt-2 text-sm text-[#5F360A]/70">나의 랭킹</p>
-                    </div>
-                    {/* 세로 구분선 */}
-                    <div className="hidden md:block w-px h-12 bg-[#e0d5c5]" />
-                    {/* ⓑ 만든 문제집 수 */}
+                    {/* 만든 문제집 수 */}
                     <div className="px-4">
                         <p className="text-4xl font-bold text-[#5F360A]">
                             {stats.createdWorkbooks}
                         </p>
-                        <p className="mt-2 text-sm text-[#5F360A]/70">만든 문제 수</p>
+                        <p className="mt-2 text-sm text-[#5F360A]/70">만든 문제집</p>
                     </div>
                     <div className="hidden md:block w-px h-12 bg-[#e0d5c5]" />
-                    {/* ⓒ 푼 문제집 수 */}
+                    {/* 업로드 문제집 수 */}
+                    <div className="px-4">
+                        <p className="text-4xl font-bold text-[#5F360A]">
+                            {stats.uploadedWorkbooks}
+                        </p>
+                        <p className="mt-2 text-sm text-[#5F360A]/70">업로드 문제집</p>
+                    </div>
+                    <div className="hidden md:block w-px h-12 bg-[#e0d5c5]" />
+                    {/* 푼 문제집 수 */}
                     <div className="px-4">
                         <p className="text-4xl font-bold text-[#5F360A]">
                             {stats.solvedWorkbooks}
                         </p>
-                        <p className="mt-2 text-sm text-[#5F360A]/70">푼 문제 수</p>
+                        <p className="mt-2 text-sm text-[#5F360A]/70">푼 문제집</p>
                     </div>
                 </section>
             </div>


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#52

## 📝 요약(Summary)
- `MyPageHome.jsx`에서 사용자 통계 정보 영역에 **업로드한 문제집 수** 항목이 추가되었습니다.
- 기존의 '만든 문제집', '푼 문제집'과 함께 통계 카드 UI 내에서 시각적으로 분리하여 출력되도록 구성하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
1. **업로드 문제집 수 시각화**  
   - 사용자 마이페이지의 통계 카드(`MyPageHome.jsx`)에 `stats.uploadedWorkbooks` 데이터를 기반으로 업로드한 문제집 수를 시각화하는 블록을 새로 추가하였습니다.
   - 해당 값은 기존의 '만든 문제집 수', '푼 문제집 수' 블록과 동일한 형태로 디자인되어 있어 일관된 UI를 유지합니다.

2. **UI 요소 정렬 및 텍스트 추가**  
   - 각 통계 수치 하단에 텍스트 라벨을 별도로 배치하여 사용자가 각 수치의 의미를 쉽게 파악할 수 있도록 개선하였습니다.
   - `만든 문제 수` 라벨이 다소 혼란을 줄 수 있어, 해당 부분을 `업로드 문제집`이라는 명확한 표현으로 정리하였습니다.

3. **기존 통계 블록 재배열 및 주석 정리**  
   - 기존 통계 항목들 간의 시각적 구분을 명확히 하기 위해 세로 구분선(`<div className="hidden md:block w-px h-12 bg-[#e0d5c5]" />`)의 위치 조정 및 추가를 진행하였습니다.
   - JSX 내 불필요하거나 혼동을 줄 수 있는 주석은 제거 또는 수정하였습니다.

## 📸스크린샷 (선택)
<!-- 변경된 통계 카드 UI 시각자료가 있다면 여기에 첨부해주세요 -->

## 💬 공유사항 to 리뷰어