### PR TITLE
[fix #55] 아이콘 위치 수정 완료

### DIFF
--- a/src/components/folder/FolderListWithDnD.jsx
+++ b/src/components/folder/FolderListWithDnD.jsx
@@ -22,8 +22,8 @@ export default function FolderListWithDnD({
   onBack,
   onToggleAll,
   isSelectMode,
-  onUpload,          // private ▸ 업로드  | public ▸ 다운로드(내 문제집으로 복사)
-  onMerge,           // private 전용: 문제집 합치기
+  onUpload,
+  onMerge,
 
   /* ───── 렌더링 props ───── */
   currentFolder,
@@ -37,7 +37,7 @@ export default function FolderListWithDnD({
   onRenameWorkbook,
   onAddFolder,
   onSelectItem,
-  filterDepth = 0,   // public 의 네비 depth(0=root)
+  filterDepth = 0,
 }) {
   const navigate = useNavigate();
   const isPublic = mode === "public";
@@ -46,17 +46,13 @@ export default function FolderListWithDnD({
   /* ───────────────────────── 상단 툴바 ───────────────────────── */
   const Toolbar = () => (
     <header className="fixed top-[66px] left-[200px] w-[calc(100%-200px)] flex items-center justify-between px-6 py-3 border-b border-[#e5d5c5] bg-[#fdf9f4] z-30">
-      {/* ← 뒤로가기 & 경로 */}
       <div className="flex items-center gap-3">
         {!isRoot && (
           <button onClick={onBack} className="text-xl text-[#5f360a] hover:opacity-70">◀</button>
         )}
         <h2 className="text-lg font-semibold text-[#5f360a]">{selectedFolder?.name ?? ""}</h2>
       </div>
-
-      {/* → 정렬 & 선택툴 */}
       <div className="flex items-center gap-3 text-sm text-[#5f360a]">
-        {/* 정렬 */}
         <div className="relative">
           <select
             value={sortOption}
@@ -70,13 +66,11 @@ export default function FolderListWithDnD({
           </select>
           <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs">▼</span>
         </div>
-
-        {/* 선택 모드 툴바 */}
         {isSelectMode && (
           <>
             {isPublic ? (
               <button
-                onClick={onUpload} // 다운로드(복사)
+                onClick={onUpload}
                 className="bg-[#AC957B] text-white px-3 py-1 rounded hover:bg-[#5F360A] transition-colors"
               >
                 다운로드
@@ -100,8 +94,6 @@ export default function FolderListWithDnD({
             <span>{selectedItems.length}개 선택</span>
           </>
         )}
-
-        {/* 선택 on/off */}
         <Checkbox checked={isSelectMode} onChange={onToggleAll} />
       </div>
     </header>
@@ -118,47 +110,33 @@ export default function FolderListWithDnD({
       },
     });
 
-    const handleRename = (e) => {
-      e.preventDefault();
-      onRename(folder.id);
-    };
-
     return (
       <div
         ref={(node) => drag(drop(node))}
-        className="relative flex flex-col items-center w-20 cursor-pointer group"
+        className="relative flex flex-col items-center w-20 self-start cursor-pointer group"
         onClick={() => onFolderClick(folder.id)}
-        onDoubleClick={handleRename}
-        onContextMenu={handleRename}
+        onDoubleClick={() => onRename(folder.id)}
+        onContextMenu={(e) => { e.preventDefault(); onRename(folder.id); }}
       >
-        {/* 삭제 */}
         <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onDeleteFolder(folder.id);
-          }}
+          onClick={(e) => { e.stopPropagation(); onDeleteFolder(folder.id); }}
           className="absolute -top-2 -right-2 w-5 h-5 bg-red-500 text-white text-xs rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
           title="삭제"
-        >
-          ×
-        </button>
+        >×</button>
 
-        {/* 폴더 그림 */}
         <div className="relative w-[80px] h-[60px]">
           <div className="absolute top-0 left-0 w-[52px] h-[16px] bg-[#E0CCB3] border border-[#BDA68A] border-b-0 rounded-tl-md rounded-tr-md" />
           <div className="absolute top-[12px] left-0 w-full h-[48px] bg-[#C9A77F] border border-[#BDA68A] rounded-md" />
         </div>
 
-        <span className="mt-2 text-sm font-medium text-[#5f360a] text-center break-words">
-          {folder.name}
-        </span>
+        <span className="mt-2 text-sm font-medium text-[#5f360a] text-center break-words">{folder.name}</span>
       </div>
     );
   };
 
   /* ───────────────────────── 폴더 추가 카드 ──────────────────── */
   const AddFolderCard = ({ onClick }) => (
-    <div onClick={onClick} className="flex flex-col items-center w-20 cursor-pointer group">
+    <div onClick={onClick} className="flex flex-col items-center w-20 self-start cursor-pointer group">
       <div className="relative w-[80px] h-[80px] border-2 border-dashed border-[#DACEC0] rounded-md flex items-center justify-center group-hover:bg-[#F5EFE9] transition-colors">
         <span className="text-3xl text-[#DAC6A6]">＋</span>
       </div>
@@ -169,64 +147,40 @@ export default function FolderListWithDnD({
   /* ───────────────────────── 문제집 카드 ─────────────────────── */
   const WorkbookItem = ({ workbook }) => {
     const navigate = useNavigate();
-
     const [, drag] = useDrag({ type: ItemTypes.WORKBOOK, item: { id: workbook.id } });
     const [, drop] = useDrop({
       accept: ItemTypes.WORKBOOK,
       drop: () => moveWorkbook(workbook.id, currentFolder.id).then(onRefresh),
     });
 
-    const handleRename = (e) => {
-      e.preventDefault();
-      onRenameWorkbook(workbook.id);
-    };
-
-    const handleClick = (e) => {
-      e.stopPropagation();
-      if (isSelectMode) {
-        onSelectItem(workbook.id);
-      } else {
-        navigate(`/solve/${workbook.id}`);
-      }
-    };
-
     return (
       <div
         ref={(node) => drag(drop(node))}
-        className="relative flex flex-col items-center w-24 cursor-pointer group"
-        onClick={handleClick}
-        onDoubleClick={handleRename}
-        onContextMenu={handleRename}
+        className="relative flex flex-col items-center w-24 self-start cursor-pointer group"
+        onClick={(e) => { e.stopPropagation(); isSelectMode ? onSelectItem(workbook.id) : navigate(`/solve/${workbook.id}`); }}
+        onDoubleClick={(e) => { e.preventDefault(); onRenameWorkbook(workbook.id); }}
+        onContextMenu={(e) => { e.preventDefault(); onRenameWorkbook(workbook.id); }}
       >
-        {/* 선택 체크박스 */}
         {isSelectMode && (
           <div className="absolute top-0.5 left-3 z-10 transform scale-75">
             <Checkbox checked={selectedItems.includes(workbook.id)} onChange={() => onSelectItem(workbook.id)} />
           </div>
         )}
 
-        {/* 삭제 */}
         {!isPublic && (
           <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onDeleteWorkbook(workbook.id);
-            }}
+            onClick={(e) => { e.stopPropagation(); onDeleteWorkbook(workbook.id); }}
             className="absolute -top-2 -right-2 w-5 h-5 bg-red-500 text-white text-xs rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
             title="삭제"
-          >
-            ×
-          </button>
+          >×</button>
         )}
 
-        {/* 썸네일 */}
         <div className="relative w-[80px] h-[80px] bg-white border border-[#DACEC0] rounded-lg flex items-center justify-center shadow-sm transition-shadow hover:shadow-md">
           <div className="absolute top-1/2 left-1/2 w-10 h-10 bg-[#F3E9DC] rounded-full transform -translate-x-1/2 -translate-y-1/2 flex items-center justify-center">
             <span className="text-xl text-[#DAC6A6]">📄</span>
           </div>
         </div>
 
-        {/* 업로드됨 아이콘 (public 전용) */}
         {isPublic && workbook.isUploaded && (
           <span className="absolute bottom-1 right-1 text-blue-500 text-lg pointer-events-none">⬇</span>
         )}
@@ -240,18 +194,9 @@ export default function FolderListWithDnD({
   return (
     <>
       <Toolbar />
-
-      {/* 리스트 */}
-      <div className="flex flex-wrap gap-6 items-center">
-        {folders.map((f) => (
-          <FolderItem key={f.id} folder={f} />
-        ))}
-
-        {workbooks.map((wb) => (
-          <WorkbookItem key={wb.id} workbook={wb} />
-        ))}
-
-        {/* private 전용 폴더 추가 */}
+      <div className="flex flex-wrap gap-6 items-start">
+        {folders.map((f) => (<FolderItem key={f.id} folder={f} />))}
+        {workbooks.map((wb) => (<WorkbookItem key={wb.id} workbook={wb} />))}
         {!isPublic && <AddFolderCard onClick={onAddFolder} />}
       </div>
     </>


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#55

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->
- `FolderListWithDnD.jsx` 내 아이콘 및 UI 요소 위치를 조정하여 레이아웃 정렬을 개선하였습니다.
- 폴더 및 문제집 아이템의 스타일 속성 중 `items-center`를 `self-start`로 변경하여 정렬 문제를 해결하였습니다.
- 사용되지 않는 중복 props 제거 및 불필요한 주석/코드 삭제로 코드 가독성을 개선하였습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
<!--- 변경 사항 및 관련 이슈에 대해 자세히 작성해주세요. -->
1. **아이콘 정렬 문제 수정**  
   - 폴더 및 문제집 아이템 컴포넌트에서 아이콘이 좌측에 너무 붙거나 상단에 밀리는 문제가 발생하였고, 해당 요소들의 CSS 속성을 `items-center`에서 `self-start`로 변경하여 보다 자연스러운 정렬로 수정하였습니다.

2. **불필요한 props 및 중복 제거**  
   - `onUpload`, `onMerge` 등의 props가 중복 선언되어 있던 부분을 제거하여 props 정의를 정리하였습니다.

3. **이벤트 핸들러 정리**  
   - `onClick`, `onDoubleClick`, `onContextMenu` 등의 이벤트 핸들러에 중복되거나 비효율적인 로직이 있었고, 이들을 간결하고 일관되게 리팩토링하였습니다.

4. **UI 구조 간소화**  
   - `<Toolbar />` 내 조건부 렌더링 구조를 단순화하고 불필요한 `<div>` 구조를 제거하였습니다.

5. **리스트 정렬 구조 변경**  
   - 기존의 `items-center`를 사용한 flex 정렬에서, 전체 wrapper를 `items-start`로 수정하여 요소들이 수직 정렬 문제 없이 표현되도록 했습니다.

## 📸스크린샷 (선택)
(필요 시 첨부)

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
- 컴포넌트 내부의 UI 요소 정렬이 실제 배치에서 의도한 대로 잘 나오는지 한번 더 확인 부탁드립니다.
- 혹시 `self-start` 사용으로 인해 다른 예상치 못한 부작용이 발생할 수 있는지도 같이 검토해주시면 감사하겠습니다.
