### PR TITLE
[FEAT #69] 회원 탈퇴 프론트 화면 구현

### DIFF
--- a/src/components/mypage/MyPageWithdraw.jsx
+++ b/src/components/mypage/MyPageWithdraw.jsx
@@ -95,7 +95,7 @@ export default function MyPageWithdraw() {
                 <p className="font-semibold text-[#5F360A] mb-2">
                     탈퇴하시는 이유를 알려주시면, 서비스 개선에 큰 도움이 됩니다.
                 </p>
-                <div className="flex flex-wrap gap-4">
+                <div className="flex flex-wrap gap-4 text-[#AC957B]">
                     <label className="flex items-center gap-2">
                         <input
                             type="checkbox"
@@ -161,7 +161,7 @@ export default function MyPageWithdraw() {
             <button
                 onClick={handleConfirm}
                 disabled={!password}
-                className="w-full bg-[#b9a997] text-white rounded-xl py-3 disabled:opacity-50"
+                className="w-full bg-[#AC957B] text-white rounded-xl hover:bg-[#5F360A] py-3 disabled:opacity-50"
             >
                 탈퇴하기
             </button>

--- a/src/components/mypage/MyPageWithdraw.jsx
+++ b/src/components/mypage/MyPageWithdraw.jsx
@@ -1,0 +1,170 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../contexts/AuthContext.jsx";
+import ConfirmPopup from "../common/ConfirmPopup.jsx";
+import InformationPopup from "../common/InformationPopup.jsx";
+// import { withdrawUser } from "../../api/userApi.js"; // 나중에 연결
+
+export default function MyPageWithdraw() {
+    const { logout } = useAuth();
+    const navigate = useNavigate();
+
+    const [reasons, setReasons] = useState({
+        contentLack: false,
+        poorExplanation: false,
+        lowQuality: false,
+        other: false,
+    });
+    const [otherText, setOtherText] = useState("");
+    const [password, setPassword] = useState("");
+    const [showConfirm, setShowConfirm] = useState(false);
+    const [info, setInfo] = useState({ open: false, msg: "" });
+
+    const handleReasonChange = (e) => {
+        const { name, checked } = e.target;
+        setReasons((prev) => ({ ...prev, [name]: checked }));
+    };
+
+    const handleConfirm = () => {
+        setShowConfirm(true);
+    };
+
+    const handleWithdraw = async () => {
+        setShowConfirm(false);
+        try {
+            // const selected = Object.entries(reasons)
+            //   .filter(([, v]) => v)
+            //   .map(([key]) =>
+            //     key === "other"
+            //       ? otherText.trim()
+            //       : key === "contentLack"
+            //       ? "원하는 콘텐츠가 부족해요."
+            //       : key === "poorExplanation"
+            //       ? "해설이 별로예요."
+            //       : "문제의 퀄리티가 떨어져요."
+            //   );
+            // await withdrawUser({ password, reasons: selected });
+            setInfo({ open: true, msg: "탈퇴가 완료되었습니다." });
+            logout();
+            navigate("/", { replace: true });
+        } catch (err) {
+            setInfo({
+                open: true,
+                msg: err.response?.data?.message || "탈퇴 중 오류가 발생했습니다.",
+            });
+        }
+    };
+
+    return (
+        <div className="bg-white rounded-3xl shadow-lg p-8 md:p-12">
+            {showConfirm && (
+                <ConfirmPopup
+                    message="정말 탈퇴하시겠습니까?"
+                    onCancel={() => setShowConfirm(false)}
+                    onConfirm={handleWithdraw}
+                />
+            )}
+            {info.open && (
+                <InformationPopup
+                    message={info.msg}
+                    onClose={() => setInfo({ open: false, msg: "" })}
+                />
+            )}
+
+            <h2 className="text-3xl font-bold text-[#5F360A] mb-4">
+                회원 탈퇴 안내
+            </h2>
+            <p className="text-[#5F360A]/80 mb-8">
+                그동안 G-Learn-E를 이용해주셔서 감사합니다.
+            </p>
+
+            {/* 복귀 불가 안내 */}
+            <section className="mb-8">
+                <p className="font-semibold text-[#5F360A] mb-2">
+                    탈퇴하시면 다음 정보는 복귀되지 않습니다.
+                </p>
+                <ul className="list-disc list-inside text-sm space-y-1 text-[#5F360A]/80">
+                    <li>문제 풀이 기록 및 통계</li>
+                    <li>생성한 문제 및 문제집</li>
+                    <li>랭킹 및 모드 정보 등</li>
+                </ul>
+            </section>
+
+            {/* 탈퇴 사유 */}
+            <section className="mb-8">
+                <p className="font-semibold text-[#5F360A] mb-2">
+                    탈퇴하시는 이유를 알려주시면, 서비스 개선에 큰 도움이 됩니다.
+                </p>
+                <div className="flex flex-wrap gap-4">
+                    <label className="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            name="contentLack"
+                            checked={reasons.contentLack}
+                            onChange={handleReasonChange}
+                        />
+                        원하는 콘텐츠가 부족해요.
+                    </label>
+                    <label className="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            name="poorExplanation"
+                            checked={reasons.poorExplanation}
+                            onChange={handleReasonChange}
+                        />
+                        해설이 별로예요.
+                    </label>
+                    <label className="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            name="lowQuality"
+                            checked={reasons.lowQuality}
+                            onChange={handleReasonChange}
+                        />
+                        문제의 퀄리티가 떨어져요.
+                    </label>
+                    <label className="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            name="other"
+                            checked={reasons.other}
+                            onChange={handleReasonChange}
+                        />
+                        기타
+                    </label>
+                    {reasons.other && (
+                        <input
+                            type="text"
+                            placeholder="입력..."
+                            value={otherText}
+                            onChange={(e) => setOtherText(e.target.value)}
+                            className="border-2 border-[#b9a997] rounded-xl px-4 py-2 w-64"
+                        />
+                    )}
+                </div>
+            </section>
+
+            {/* 비밀번호 확인 */}
+            <section className="mb-8">
+                <p className="font-semibold text-[#5F360A] mb-2">
+                    탈퇴 처리를 위해 비밀번호를 다시 입력해 주세요.
+                </p>
+                <input
+                    type="password"
+                    placeholder="비밀번호"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="border-2 border-[#b9a997] rounded-xl w-full h-12 px-4 focus:outline-none"
+                />
+            </section>
+
+            <button
+                onClick={handleConfirm}
+                disabled={!password}
+                className="w-full bg-[#b9a997] text-white rounded-xl py-3 disabled:opacity-50"
+            >
+                탈퇴하기
+            </button>
+        </div>
+    );
+}

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -5,6 +5,7 @@ import MyPageSidebar from '../components/mypage/MyPageSidebar.jsx';
 import MyPageHome from '../components/mypage/MyPageHome.jsx';
 import MyPageInfo from '../components/mypage/MyPageInfo.jsx';
 import MyPageStatistics from '../components/mypage/MyPageStatistics.jsx';
+import MyPageWithdraw from '../components/mypage/MyPageWithdraw.jsx';
 
 const Mypage = () => {
     const [activeTab, setActiveTab] = useState('home');
@@ -27,11 +28,7 @@ const Mypage = () => {
                         {activeTab === 'home' && <MyPageHome />}
                         {activeTab === 'info' && <MyPageInfo />}
                         {activeTab === 'statistics' && <MyPageStatistics />}
-                        {activeTab === 'withdraw' && (
-                            <div>
-                                <p>정말 탈퇴하시겠습니까?</p>
-                            </div>
-                        )}
+                        {activeTab === 'withdraw' && <MyPageWithdraw />}
                     </div>
                 </main>
             </div>


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#69

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->

- `MyPageWithdraw.jsx` 컴포넌트를 새로 생성하여 회원 탈퇴 화면 UI 및 기능 구현
- `MyPage.jsx`에서 기존 탈퇴 관련 임시 UI를 제거하고, 새로 만든 `MyPageWithdraw` 컴포넌트로 대체

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
<!--- 변경 사항 및 관련 이슈에 대해 자세히 작성해주세요. -->

1. `src/components/mypage/MyPageWithdraw.jsx` 파일을 새로 생성하여, 회원 탈퇴 절차를 위한 UI를 구현하였습니다. 사용자는 탈퇴 사유를 체크박스로 선택할 수 있으며, 기타 사유 입력창과 비밀번호 입력창이 함께 제공됩니다. 탈퇴 버튼을 누르면 확인 팝업과 결과 알림 팝업이 연동되어 UX 흐름이 자연스럽게 이어지도록 구성하였습니다.

2. `src/pages/MyPage.jsx`의 기존 `withdraw` 탭에 있던 간단한 텍스트 안내(`정말 탈퇴하시겠습니까?`)를 제거하고, 위에서 만든 `MyPageWithdraw` 컴포넌트를 해당 탭에서 렌더링하도록 수정하였습니다. 이를 통해 UI 일관성을 높이고, 코드 구조를 개선하였습니다.

## 📸스크린샷 (선택)
<img width="1439" alt="스크린샷 2025-05-22 오후 4 02 04" src="https://github.com/user-attachments/assets/64ed5259-c49e-411d-af6b-db834eea2288" />


## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
- `MyPageWithdraw.jsx`에서 `withdrawUser` API 연결 부분은 주석 처리해두었습니다. BE 연동 시 해당 주석 부분을 해제하여 사용하시면 됩니다.
- UI 및 UX 흐름에 어색한 부분이 없는지 봐주시면 감사하겠습니다.
