### PR TITLE
[REFACTOR #72] 공개 폴더 페이지네이션 안정화 및 다중 다운로드 기능 추가

### DIFF
--- a/src/api/publicFolderApi.js
+++ b/src/api/publicFolderApi.js
@@ -27,3 +27,12 @@ export function copyWorkbookToPrivate(workbookId) {
         .post(`/api/workbook/${workbookId}/upload`)
         .then(res => res.data);
 }
+
+
+/**
+* 공개 워크북 다운로드(Private로 복사)
+* POST /api/workbook/{workbookId}/download
+*/
+export function downloadWorkbook(workbookId) {
+    return axios.post(`/api/workbook/${workbookId}/download`);
+}

--- a/src/api/publicFolderApi.js
+++ b/src/api/publicFolderApi.js
@@ -34,5 +34,5 @@ export function copyWorkbookToPrivate(workbookId) {
 * POST /api/workbook/{workbookId}/download
 */
 export function downloadWorkbook(workbookId) {
-    return axios.post(`/api/workbook/${workbookId}/download`);
+    return axiosInstance.post(`/api/workbook/${workbookId}/download`);
 }

--- a/src/api/publicWorkbooksApi.js
+++ b/src/api/publicWorkbooksApi.js
@@ -82,3 +82,5 @@ export const searchWorkbooks = ({
     axios.get("/api/search", {
         params: { keyword, range, type, page, size, sort, order },
     });
+
+

--- a/src/api/publicWorkbooksApi.js
+++ b/src/api/publicWorkbooksApi.js
@@ -71,14 +71,14 @@ export const getPublicWorkbooksBySubject = (subjectId, page, size, sort, order) 
  * 워크북 검색 (전체 / 공개 / 비공개 범위, 키워드 종류, 페이징/정렬)
  */
 export const searchWorkbooks = ({
-  keyword,
-  range = "all",
-  type = "total",
-  page = 0,
-  size = 25,
-  sort = "relevance",
-  order = "desc",
+    keyword,
+    range = "all",
+    type = "total",
+    page = 0,
+    size = 25,
+    sort = "relevance",
+    order = "desc",
 }) =>
-  axios.get("/api/search", {
-    params: { keyword, range, type, page, size, sort, order },
-  });
+    axios.get("/api/search", {
+        params: { keyword, range, type, page, size, sort, order },
+    });

--- a/src/components/common/DownloadPopup.jsx
+++ b/src/components/common/DownloadPopup.jsx
@@ -2,10 +2,17 @@ import React from "react";
 
 /**
  * DownloadPopup 모달 컴포넌트
- * mode: "confirm" | "cancelled" | "exists"
+ * mode: "confirm" | "result" | "cancelled" | "exists"
  * selectedCount: 선택된 문제집 개수
+ * result: { success: number, fail: number }
  */
-export default function DownloadPopup({ mode, selectedCount, onConfirm, onClose }) {
+export default function DownloadPopup({
+    mode,
+    selectedCount,
+    result,
+    onConfirm,
+    onClose,
+}) {
     let message;
     let buttons;
 
@@ -29,6 +36,25 @@ export default function DownloadPopup({ mode, selectedCount, onConfirm, onClose 
                 </>
             );
             break;
+
+        case "result":
+            // 다운로드 직후에만 표시할 간단한 통계창
+            return (
+                <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+                    <div className="bg-white p-6 rounded-2xl w-[320px] text-center shadow-md">
+                        <p className="text-base text-[#5f360a] mb-6">
+                            총 {selectedCount}개 중<br />
+                            ✓ {result.success}개 성공, ✕ {result.fail}개 실패
+                        </p>
+                        <button
+                            onClick={onClose}
+                            className="px-4 py-2 border border-[#AC957B] rounded-full text-[#5f360a] hover:bg-[#F5EFE9] transition"
+                        >
+                            확인
+                        </button>
+                    </div>
+                </div>
+            );
 
         case "cancelled":
             message = "문제 업로드를 취소했습니다.";
@@ -58,13 +84,12 @@ export default function DownloadPopup({ mode, selectedCount, onConfirm, onClose 
             return null;
     }
 
+    // confirm / cancelled / exists 모드 공통 렌더링
     return (
         <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
             <div className="bg-white p-6 rounded-2xl w-[320px] text-center shadow-md">
                 <p className="text-base text-[#5f360a] mb-6">{message}</p>
-                <div className="flex justify-center gap-4">
-                    {buttons}
-                </div>
+                <div className="flex justify-center gap-4">{buttons}</div>
             </div>
         </div>
     );

--- a/src/components/common/DownloadPopup.jsx
+++ b/src/components/common/DownloadPopup.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+/**
+ * DownloadPopup 모달 컴포넌트
+ * mode: "confirm" | "cancelled" | "exists"
+ * selectedCount: 선택된 문제집 개수
+ */
+export default function DownloadPopup({ mode, selectedCount, onConfirm, onClose }) {
+    let message;
+    let buttons;
+
+    switch (mode) {
+        case "confirm":
+            message = `선택한 ${selectedCount}문제집을 Private으로 다운로드하시겠습니까?`;
+            buttons = (
+                <>
+                    <button
+                        onClick={onClose}
+                        className="px-4 py-2 border border-[#AC957B] rounded-full text-[#5f360a] hover:bg-[#F5EFE9] transition"
+                    >
+                        취소
+                    </button>
+                    <button
+                        onClick={onConfirm}
+                        className="px-4 py-2 bg-[#AC957B] text-white rounded-full hover:bg-[#5F360A] transition"
+                    >
+                        확인
+                    </button>
+                </>
+            );
+            break;
+
+        case "cancelled":
+            message = "문제 업로드를 취소했습니다.";
+            buttons = (
+                <button
+                    onClick={onClose}
+                    className="px-4 py-2 border border-[#AC957B] rounded-full text-[#5f360a] hover:bg-[#F5EFE9] transition"
+                >
+                    확인
+                </button>
+            );
+            break;
+
+        case "exists":
+            message = "문제가 이미 업로드되어 있습니다.";
+            buttons = (
+                <button
+                    onClick={onClose}
+                    className="px-4 py-2 border border-[#AC957B] rounded-full text-[#5f360a] hover:bg-[#F5EFE9] transition"
+                >
+                    확인
+                </button>
+            );
+            break;
+
+        default:
+            return null;
+    }
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+            <div className="bg-white p-6 rounded-2xl w-[320px] text-center shadow-md">
+                <p className="text-base text-[#5f360a] mb-6">{message}</p>
+                <div className="flex justify-center gap-4">
+                    {buttons}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/folder/PublicMain.jsx
+++ b/src/components/folder/PublicMain.jsx
@@ -39,6 +39,7 @@ export default function PublicMain({
   setSelectedDepartment,
   setSelectedSubject,
   sidebarRef,
+  onSwitchTab,
 }) {
   /* ❖ filterDepth: 0(루트) → 1(단과) → 2(학과) → 3(과목) */
   const filterDepth = selectedSubject
@@ -57,6 +58,7 @@ export default function PublicMain({
   const [isSelectMode, setIsSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState([]);
   const [downloadMode, setDownloadMode] = useState(null);
+  const [downloadResult, setDownloadResult] = useState({ success: 0, fail: 0 });
   const [downloading, setDownloading] = useState(false);
   const [history, setHistory] = useState([]);
   const [, startTransition] = useTransition();
@@ -247,22 +249,31 @@ export default function PublicMain({
 
   const handleDownloadConfirm = async () => {
     setDownloading(true);
-    try {
-      // 호출할 API: POST /api/workbook/{id}/download
-      await Promise.all(
-        selectedIds.map(id => downloadWorkbook(id)) // downloadWorkbook 함수 정의 필요
-      );
-      setDownloadMode("cancelled");  // 성공 후 메시지 모드 변경
-    } catch (err) {
-      console.error(err);
-      setDownloadMode("exists");     // 이미 다운된 경우
-    } finally {
-      setDownloading(false);
-      setSelectedIds([]);
-      setIsSelectMode(false);
+    let success = 0, fail = 0;
+    for (const id of selectedIds) {
+      try {
+        await downloadWorkbook(id);
+        success++;
+      } catch (err) {
+        console.error(`다운로드 실패 (id=${id})`, err);
+        fail++;
+      }
     }
+
+    setDownloading(false);
+    setDownloadResult({ success, fail });
+    setDownloadMode("result");       // ③ 결과 모드로 전환
+    setSelectedIds([]);
+    setIsSelectMode(false);
+
+    // ④ Private 탭으로 자동 전환
+    onSwitchTab("private");
   };
-  const handleDownloadClose = () => setDownloadMode(null);
+
+  const handleDownloadClose = () => {
+    setDownloadMode(null);
+  };
+
 
   /* ───────────────── 5) 폴더 클릭 시 이동 ───────────────── */
   const handleFolderClick = useCallback(
@@ -383,6 +394,7 @@ export default function PublicMain({
         <DownloadPopup
           mode={downloadMode}
           selectedCount={selectedIds.length}
+          result={downloadResult}
           onConfirm={handleDownloadConfirm}
           onClose={handleDownloadClose}
         />

--- a/src/components/folder/PublicMain.jsx
+++ b/src/components/folder/PublicMain.jsx
@@ -8,8 +8,8 @@ import React, {
 } from "react";
 import { useDrop } from "react-dnd";
 import FolderListWithDnD from "./FolderListWithDnD.jsx";
-import UploadPopup from "../common/UploadPopup.jsx";
-import { copyWorkbookToPrivate } from "../../api/publicFolderApi";
+import DownloadPopup from "../common/DownloadPopup.jsx";
+import { downloadWorkbook } from "../../api/publicFolderApi";
 
 import {
   // 공개 워크북 조회 API들
@@ -56,9 +56,23 @@ export default function PublicMain({
   const [sortOption, setSortOption] = useState("name");
   const [isSelectMode, setIsSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState([]);
-  const [showCopyPopup, setShowCopyPopup] = useState(false);
+  const [downloadMode, setDownloadMode] = useState(null);
+  const [downloading, setDownloading] = useState(false);
   const [history, setHistory] = useState([]);
   const [, startTransition] = useTransition();
+
+  // 전체 선택 모드 토글
+  const toggleSelectMode = () => {
+    setIsSelectMode(prev => !prev);
+    if (isSelectMode) setSelectedIds([]);
+  };
+
+  // 워크북 선택/해제 핸들러
+  const handleSelect = (id) => {
+    setSelectedIds(prev =>
+      prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
+    );
+  };
 
   // ───────────────── pagination state ─────────────────
   const [page, setPage] = useState(0);
@@ -218,6 +232,10 @@ export default function PublicMain({
 
     loadFolders();
   }, [selectedCollege, selectedDepartment, selectedSubject, filterDepth, selectedYear]);
+  const makeTitle = () =>
+    [selectedCollege?.name, selectedDepartment?.name, selectedSubject?.name]
+      .filter(Boolean)
+      .join(" - ") || "Public";
 
   /* ───────────────── 3) 클라이언트 정렬 ───────────────── */
   const sortedWorkbooks = useMemo(() => {
@@ -227,21 +245,24 @@ export default function PublicMain({
     );
   }, [workbooks, sortOption]);
 
-  /* ───────────────── 4) 선택·다운로드 핸들러 ───────────────── */
-  const toggleSelectMode = () => {
-    setIsSelectMode(m => !m);
-    if (isSelectMode) setSelectedIds([]);
+  const handleDownloadConfirm = async () => {
+    setDownloading(true);
+    try {
+      // 호출할 API: POST /api/workbook/{id}/download
+      await Promise.all(
+        selectedIds.map(id => downloadWorkbook(id)) // downloadWorkbook 함수 정의 필요
+      );
+      setDownloadMode("cancelled");  // 성공 후 메시지 모드 변경
+    } catch (err) {
+      console.error(err);
+      setDownloadMode("exists");     // 이미 다운된 경우
+    } finally {
+      setDownloading(false);
+      setSelectedIds([]);
+      setIsSelectMode(false);
+    }
   };
-  const handleSelect = id =>
-    setSelectedIds(prev =>
-      prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id],
-    );
-
-  /* ❖ 현재 경로 타이틀 */
-  const makeTitle = () =>
-    [selectedCollege?.name, selectedDepartment?.name, selectedSubject?.name]
-      .filter(Boolean)
-      .join(" - ") || "Public";
+  const handleDownloadClose = () => setDownloadMode(null);
 
   /* ───────────────── 5) 폴더 클릭 시 이동 ───────────────── */
   const handleFolderClick = useCallback(
@@ -319,7 +340,10 @@ export default function PublicMain({
         onBack={handleBack}
         onToggleAll={toggleSelectMode}
         isSelectMode={isSelectMode}
-        onDownload={() => setShowCopyPopup(true)}
+        onDownload={() => {
+          if (selectedIds.length === 0) return;
+          setDownloadMode("confirm");
+        }}
         currentFolder={{ id: null }}
         folders={paginatedFolders}
         workbooks={filterDepth === 3 ? sortedWorkbooks : []}
@@ -354,17 +378,13 @@ export default function PublicMain({
           Next ▶
         </button>
       </div>
-      {/* 공개 → 내 워크북 복사 팝업 */}
-      {showCopyPopup && (
-        <UploadPopup
-          mode="copyToPrivate"
-          selectedWorkbooks={workbooks.filter(w => selectedIds.includes(w.id))}
-          onConfirm={async () => {
-            await Promise.all(selectedIds.map(id => copyWorkbookToPrivate(id)));
-            setShowCopyPopup(false);
-            setSelectedIds([]);
-          }}
-          onClose={() => setShowCopyPopup(false)}
+
+      {downloadMode && (
+        <DownloadPopup
+          mode={downloadMode}
+          selectedCount={selectedIds.length}
+          onConfirm={handleDownloadConfirm}
+          onClose={handleDownloadClose}
         />
       )}
     </main>

--- a/src/components/folder/PublicMain.jsx
+++ b/src/components/folder/PublicMain.jsx
@@ -239,7 +239,6 @@ export default function PublicMain({
       .filter(Boolean)
       .join(" - ") || "Public";
 
-  /* ───────────────── 3) 클라이언트 정렬 ───────────────── */
   const sortedWorkbooks = useMemo(() => {
     if (sortOption !== "name") return workbooks;
     return [...workbooks].sort((a, b) =>
@@ -250,24 +249,24 @@ export default function PublicMain({
   const handleDownloadConfirm = async () => {
     setDownloading(true);
     let success = 0, fail = 0;
-    for (const id of selectedIds) {
+    await Promise.all(selectedIds.map(async id => {
       try {
         await downloadWorkbook(id);
         success++;
-      } catch (err) {
-        console.error(`다운로드 실패 (id=${id})`, err);
+      } catch {
         fail++;
       }
-    }
-
+    }));
     setDownloading(false);
+    setDownloadMode("result");
     setDownloadResult({ success, fail });
-    setDownloadMode("result");       // ③ 결과 모드로 전환
     setSelectedIds([]);
     setIsSelectMode(false);
 
     // ④ Private 탭으로 자동 전환
-    onSwitchTab("private");
+    setTimeout(() => {
+      onSwitchTab("private");
+    }, 1000);
   };
 
   const handleDownloadClose = () => {

--- a/src/components/folder/PublicMain.jsx
+++ b/src/components/folder/PublicMain.jsx
@@ -172,11 +172,15 @@ export default function PublicMain({
             type: "college",
           }));
           const liberal = (liberalRes.data.data || [])[0];
-          setItems(
-            liberal
-              ? [...colleges, { id: liberal.id, name: liberal.collegeName, type: "college" }]
-              : colleges,
+          const combined = liberal
+            ? [...colleges, { id: liberal.id, name: liberal.collegeName, type: "college" }]
+            : colleges;
+
+          // ID 기준으로 중복 제거
+          const uniqueItems = Array.from(
+            new Map(combined.map(item => [item.id, item])).values()
           );
+          setItems(uniqueItems);
         } else if (filterDepth === 1 && selectedCollege) {
           /* 단과 안: 학과/교양 영역 */
           const res = await getDepartments(selectedCollege.id);

--- a/src/components/folder/PublicMain.jsx
+++ b/src/components/folder/PublicMain.jsx
@@ -32,8 +32,6 @@ export default function PublicMain({
   selectedDepartment = null,       // { id, name } | null
   selectedSubject = null,          // { id, name } | null
   selectedYear = "",
-  page = 0,
-  size = 20,
   sort = "name",
   order = "asc",
   handleBack,
@@ -42,6 +40,15 @@ export default function PublicMain({
   setSelectedSubject,
   sidebarRef,
 }) {
+  /* ❖ filterDepth: 0(루트) → 1(단과) → 2(학과) → 3(과목) */
+  const filterDepth = selectedSubject
+    ? 3
+    : selectedDepartment
+      ? 2
+      : selectedCollege
+        ? 1
+        : 0;
+
   /* ───────────────── state ───────────────── */
   const [items, setItems] = useState([]);       // 왼쪽 폴더(단과·학과·과목) 리스트
   const [workbooks, setWorkbooks] = useState([]);       // 문제집 리스트
@@ -51,18 +58,49 @@ export default function PublicMain({
   const [selectedIds, setSelectedIds] = useState([]);
   const [showCopyPopup, setShowCopyPopup] = useState(false);
   const [history, setHistory] = useState([]);
-
-  /* ❖ useTransition  – isPending은 쓰지 않으므로 생략 */
   const [, startTransition] = useTransition();
 
-  /* ❖ filterDepth: 0(루트) → 1(단과) → 2(학과) → 3(과목) */
-  const filterDepth = selectedSubject
-    ? 3
-    : selectedDepartment
-      ? 2
-      : selectedCollege
-        ? 1
-        : 0;
+  // ───────────────── pagination state ─────────────────
+  const [page, setPage] = useState(0);
+  const size = 20;
+  const [pageInfo, setPageInfo] = useState({
+    totalPages: 1,
+    pageNumber: 0,
+    hasNextPage: false,
+    hasPreviousPage: false,
+  });
+
+  // ───────────────── folder-side pagination 계산 ─────────────────
+  const folderTotalPages = Math.max(1, Math.ceil(items.length / size));
+  useEffect(() => {
+    if (filterDepth < 3) {
+      const maxPage = Math.max(0, folderTotalPages - 1);
+      if (page > maxPage) setPage(maxPage);
+    }
+  }, [folderTotalPages, filterDepth, page]);
+
+  // ② 실제로 화면에 뿌릴 슬라이스
+  const paginatedFolders = useMemo(() => {
+    if (filterDepth < 3) {
+      const start = page * size;
+      return items.slice(start, start + size);
+    }
+    return items;
+  }, [items, page, size, filterDepth]);
+
+
+  const folderPageInfo = useMemo(() => ({
+    totalPages: folderTotalPages,
+    pageNumber: page,
+    hasNextPage: page < folderTotalPages - 1,
+    hasPreviousPage: page > 0,
+  }), [folderTotalPages, page]);
+
+  const displayPageInfo = filterDepth < 3 ? folderPageInfo : pageInfo;
+
+  /* depth 바뀌면 page 초기화 */
+  useEffect(() => { setPage(0); }, [filterDepth]);
+
 
   /* ───────────────── 1) 공개 워크북 로딩 ───────────────── */
   useEffect(() => {
@@ -87,7 +125,15 @@ export default function PublicMain({
           );
         }
 
-        setWorkbooks(res?.data?.data?.publicWorkbooks ?? []);
+        // ─── publicWorkbooks 과 pageInfo 를 분리하여 저장
+        const { publicWorkbooks, pageInfo: pi } = res.data.data;
+        setWorkbooks(publicWorkbooks ?? []);
+        setPageInfo({
+          totalPages: pi.totalPages,
+          pageNumber: pi.pageNumber,
+          hasNextPage: pi.hasNextPage,
+          hasPreviousPage: pi.hasPreviousPage,
+        });
       } catch (err) {
         console.error("공개 워크북 로딩 실패:", err);
         setWorkbooks([]);
@@ -271,7 +317,7 @@ export default function PublicMain({
         isSelectMode={isSelectMode}
         onDownload={() => setShowCopyPopup(true)}
         currentFolder={{ id: null }}
-        folders={items}
+        folders={paginatedFolders}
         workbooks={filterDepth === 3 ? sortedWorkbooks : []}
         onRefresh={() => { }}
         onFolderClick={handleFolderClick}
@@ -282,7 +328,28 @@ export default function PublicMain({
         onAddFolder={null}
         onSelectItem={handleSelect}
       />
+      {/* ───── pagination controls ───── */}
+      <div className="fixed bottom-8 left-1/2  flex justify-center items-center gap-4 ">
+        <button
+          onClick={() => setPage(p => Math.max(p - 1, 0))}
+          disabled={!displayPageInfo.hasPreviousPage}
+          className="px-3 py-1 border rounded disabled:opacity-40"
+        >
+          ◀ Prev
+        </button>
 
+        <span className="px-2">
+          {displayPageInfo.pageNumber + 1} / {displayPageInfo.totalPages}
+        </span>
+
+        <button
+          onClick={() => setPage(p => p + 1)}
+          disabled={!displayPageInfo.hasNextPage}
+          className="px-3 py-1 border rounded disabled:opacity-40"
+        >
+          Next ▶
+        </button>
+      </div>
       {/* 공개 → 내 워크북 복사 팝업 */}
       {showCopyPopup && (
         <UploadPopup

--- a/src/pages/FolderPage.jsx
+++ b/src/pages/FolderPage.jsx
@@ -216,7 +216,7 @@ const LeftSidebar = React.forwardRef(function LeftSidebar({
               <option value="">{isGeneral ? "영역" : "학과"} 선택</option>
               {lv2.map((d) => (
                 <option key={d.id} value={d.id}>
-                  {isGeneral ? d : d.departmentName}
+                  {d.departmentName}
                 </option>
               ))}
             </select>

--- a/src/pages/FolderPage.jsx
+++ b/src/pages/FolderPage.jsx
@@ -305,6 +305,7 @@ export default function FolderPage() {
             <PrivateMain />
           ) : (
             <PublicMain
+              onSwitchTab={setTab}
               selectedCollege={selectedCollege}
               selectedDepartment={selectedDepartment}
               selectedSubject={selectedSubject}


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #이슈번호 -->
#72

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대한 핵심 내용을 간단하게 작성해주세요. -->

- `PublicMain.jsx`에서 폴더 페이지네이션 로직 안정화 및 렌더링 방식 개선
- 공개 워크북 다중 다운로드 기능 추가 및 다운로드 결과 팝업 구현
- `publicFolderApi.js`에 공개 워크북 다운로드 API 추가
- `DownloadPopup.jsx` 신규 컴포넌트 추가 (다운로드 확인 및 결과 표시)
- `publicWorkbooksApi.js` 내 불필요한 들여쓰기 수정 및 정리
- `FolderPage.jsx`에서 잘못된 select option 렌더링 버그 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
<!--- 변경 사항 및 관련 이슈에 대해 자세히 작성해주세요. -->

1. **폴더 페이지네이션 안정화 및 중복 제거 로직 리팩토링**
   - `PublicMain.jsx`에서 폴더 리스트 렌더링 시 전체 리스트를 페이징 처리하고, depth 변경 시 페이지 초기화 처리 로직을 추가했습니다.
   - 중복된 폴더(같은 ID)가 존재할 경우 이를 제거하도록 `Map`을 활용한 필터링 로직을 추가하였습니다.

2. **공개 문제집 다중 다운로드 기능 및 결과 팝업 구현**
   - 여러 워크북을 선택해 한 번에 다운로드할 수 있도록 기능 추가 (`selectedIds` 기반).
   - 다운로드 성공/실패 건수를 보여주는 `DownloadPopup` 모달 구현 및 적용.
   - 다운로드 후 1초 뒤 자동으로 Private 탭으로 전환되도록 UX 개선.

3. **공개 워크북 다운로드 API 연동**
   - `publicFolderApi.js`에 `/api/workbook/{workbookId}/download` API를 연동하는 `downloadWorkbook` 함수 추가.

4. **DownloadPopup 컴포넌트 신설**
   - `DownloadPopup.jsx`에 확인 모드, 결과 모드, 이미 존재/취소 모드별 메시지 및 버튼 렌더링 구현.
   - 공통 모달 스타일을 적용하여 사용자 경험 일관성을 유지했습니다.

5. **불필요한 들여쓰기 수정**
   - `publicWorkbooksApi.js`에서 들여쓰기 오류 수정으로 가독성을 개선하였습니다.

6. **FolderPage 내 select option 렌더링 버그 수정**
   - 학과명 대신 객체 전체를 렌더링하던 오류 수정: `d.departmentName`으로 수정.

## 📸스크린샷 (선택)
- 다운로드 팝업 UI 및 결과 팝업은 `DownloadPopup.jsx` 참조

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
- 다운로드 로직이 `Promise.all` 기반으로 병렬 처리되는데, 추후 서버 부하 이슈가 있을지 고려 필요합니다.
- `onSwitchTab("private")` 호출 시점이 UX적으로 적절한지 확인 부탁드립니다.
