### PR TITLE
Refactor[#84] 이름,이메일 매칭 여부

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -33,8 +33,16 @@ export const signup = async (name, nickname, email, password, collegeId, departm
 
 
 // 비밀번호 초기화 관련
-export const issuePasswordResetEmailCode = async (email) => {
-    const res = await axios.get(`/api/auth/password-reset-code?email=${email}`);
+/**
+ * 이름과 이메일이 일치하는 사용자가 있는지 확인하고, 있다면 비밀번호 재설정 이메일 코드를 발급합니다.
+ * @param {string} name - 사용자 이름
+ * @param {string} email - 사용자 이메일
+ * @returns {Promise}
+ */
+export const issuePasswordResetEmailCode = async (name, email) => {
+    const res = await axios.get(`/api/auth/password-reset-code`, {
+        params: { name, email }
+    });
     return res; // { message }
 }
 

--- a/src/pages/FindPassword.jsx
+++ b/src/pages/FindPassword.jsx
@@ -7,7 +7,6 @@ import {
   verifyPasswordResetEmailCode,
   resetPassword,
 } from "../api/authApi.js";
-// 유틸리티 함수 import
 import { validatePassword, validatePasswordRule } from "../utils/passwordValidator.js";
 
 export default function FindPassword() {
@@ -39,7 +38,9 @@ export default function FindPassword() {
   const handleSendCode = async () => {
     try {
       setError("");
-      await issuePasswordResetEmailCode(email);
+      console.log(name);
+      console.log(email);
+      await issuePasswordResetEmailCode(name, email); // ✅ name도 함께 전송
       setEmailSent(true);
       setVerified(false);
       setPopupMessage("인증 메일이 전송되었습니다!");
@@ -143,14 +144,18 @@ export default function FindPassword() {
                   className="flex-1 border border-[#5F360A] px-4 py-2 rounded focus:outline-none"
                   required
                 />
+
                 <button
                   type="button"
                   onClick={handleSendCode}
-                  className="bg-[#AC957B] text-white px-3 py-2 text-sm rounded hover:bg-[#432707]"
+                  className="bg-[#AC957B] text-white px-3 py-2 text-sm rounded hover:bg-[#432707] disabled:opacity-50 disabled:cursor-not-allowed"
+                  disabled={!name || !email} // ✅ 입력 안 되면 버튼 비활성화
                 >
                   인증코드 전송
                 </button>
               </div>
+              {/* 이메일/인증 관련 에러 메시지 */}
+              {!verified && error && <p className="text-sm text-red-500 mt-1 text-left">{error}</p>}
             </div>
 
             <input
@@ -167,9 +172,6 @@ export default function FindPassword() {
             >
               인증 하기
             </button>
-            {/* 이메일/인증 관련 에러는 여기에 표시 */}
-            {!verified && error && <p className="text-sm text-red-500">{error}</p>}
-
 
             <hr className="my-4 border-[#ddd]" />
 
@@ -200,7 +202,7 @@ export default function FindPassword() {
                   />
                 </div>
 
-                {/* 비밀번호 관련 에러는 여기에 표시되도록 위치 변경 */}
+                {/* 비밀번호 관련 에러 */}
                 {error && <p className="text-sm text-red-500 text-left mt-1">{error}</p>}
 
                 <button
@@ -217,4 +219,3 @@ export default function FindPassword() {
     </>
   );
 }
-


### PR DESCRIPTION
## #️⃣ Issue Number
<!--- ex) #84 -->
#84

## 📝 요약(Summary)
- `authApi.js`: 비밀번호 재설정 API 요청 시 이름과 이메일을 함께 전달하도록 수정
- `FindPassword.jsx`: 이름과 이메일을 모두 입력해야 인증 코드 전송 가능하도록 로직 개선 및 버튼 비활성화 처리 추가
- `FindPassword.jsx`: 에러 메시지 표시 위치 및 중복 제거로 UI 정리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 상세 설명(Details)
1. **`authApi.js` 수정**  
   - 기존에는 이메일만으로 비밀번호 재설정 이메일 코드를 요청했으나, 보안 강화를 위해 이름과 이메일을 함께 전달하도록 수정했습니다.  
   - Axios 요청 시 `params` 객체를 사용하여 `{ name, email }`을 서버로 전송합니다.  

2. **`FindPassword.jsx` 인증 코드 전송 로직 개선**  
   - `handleSendCode` 함수에서 `issuePasswordResetEmailCode(name, email)` 형태로 호출되도록 변경했습니다.  
   - 버튼에 `disabled={!name || !email}` 조건을 추가하여, 이름과 이메일이 모두 입력되지 않으면 전송 버튼이 비활성화되도록 처리했습니다.  
   - 사용자가 입력 조건을 충족하지 않은 상태에서 잘못된 요청을 보내는 것을 방지합니다.  

3. **에러 메시지 표시 정리**  
   - 인증 관련 에러 메시지가 중복으로 출력되던 부분을 제거했습니다.  
   - 비밀번호 관련 에러 메시지는 입력 필드와 더 가깝게 배치하여 사용자가 즉시 확인할 수 있도록 UI를 개선했습니다.  

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
- API 요청 파라미터 변경(`email` → `name, email`)으로 인해 BE 연동이 정상적으로 되는지 확인이 필요합니다.  
- 인증/에러 메시지 출력 위치에 대해 UI/UX적으로 더 적합한 위치가 있는지 의견을 주시면 좋겠습니다.  
